### PR TITLE
Updated js-quantities version, added check for compatibility to equals method

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "js-quantities": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.6.3.tgz",
-      "from": "js-quantities@1.6.3"
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.6.6.tgz",
+      "from": "js-quantities@1.6.6"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ with the additional methods:
 * .typeName() - returns 'js-quantity'
 * .toJSONValue() - returns a JSON-ifyable string
 * .clone() - Returns a new Qty object equal to the argument.
-* .equals() - defers to Qty.eq() method
+* .equals() - defers to Qty.eq() method if units are compatible; false otherwise

--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ Qty.prototype.clone = function clone() {
 	return new Qty(this);
 };
 
-Qty.prototype.equals = Qty.prototype.eq;
+Qty.prototype.equals = function equals(other) {
+        if (this.isCompatible(other)) {
+                return this.eq(other);
+        } else {
+                return false;
+        }
+}
 
 export default Qty;

--- a/package.js
+++ b/package.js
@@ -1,13 +1,13 @@
 Package.describe({
   name: 'fathom:quantities',
-  version: '1.0.1',
+  version: '1.0.2',
   summary: 'Allows Meteor to understand physical units (including conversions and formatting).',
   git: 'https://github.com/studioFATHOM/meteor-quantities.git',
   documentation: 'README.md'
 });
 
 Npm.depends( {
-  'js-quantities': '1.6.3'
+  'js-quantities': '1.6.6'
 });
 
 Package.onUse(function(api) {

--- a/test.js
+++ b/test.js
@@ -46,6 +46,12 @@ Tinytest.add('Compare two quantities', function(test) {
   test.isFalse(EJSON.equals(qty1, qty3), '`10 cm` is not equal to `1 mile`');
 });
 
+Tinytest.add('Compare two incompatible quantities', function(test) {
+  let qty1 = Qty('1 cm');
+  let qty2 = Qty('1 C');
+  test.isFalse(EJSON.equals(qty1, qty2), '`1 cm` is not equal to `1 C`');
+});
+
 Tinytest.add('Clone a quantity', function(test) {
   let qty1 = Qty('10 cm');
   let qty2 = EJSON.clone(qty1);


### PR DESCRIPTION
Now fathom:quantities points to the latest js-quantities, which provides better error reporting.

The equals method also checks for unit compatibility between its parameters. This prevents the continual exceptions we got from observeChanges when one Quantity object replaced another, incompatible one.